### PR TITLE
Update repo URL and author info

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ test.end();
 
 ## License ##
 
-MIT. See [LICENSE.md](http://github.com/CodeAdventure/ase-utils/blob/master/LICENSE.md) for details.
+MIT. See [LICENSE.md](http://github.com/DominikGuzei/node-ase-utils/blob/master/LICENSE.md) for details.

--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
   },
   "author": {
     "name": "Dominik Guzei",
-    "email": "office@codeadventure.com",
-    "url": "http://www.codeadventure.com"
+    "email": "dominik.guzei@gmail.com",
+    "url": "https://www.highest.vision/"
   },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/CodeAdventure/ase-utils"
+    "url": "git://github.com/DominikGuzei/node-ase-utils"
   },
   "bugs": {
-    "url": "https://github.com/CodeAdventure/ase-utils/issues"
+    "url": "https://github.com/DominikGuzei/node-ase-utils/issues"
   }
 }


### PR DESCRIPTION
The latest published version of [this package](https://www.npmjs.com/package/ase-utils) points to 404 URLs as the repo/homepage links. Updating meta with the new location of the repo. (Will probably need to cut v0.1.2 and publish after this.)

Thanks for this library!